### PR TITLE
tweaks!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitodl/ckeditor-custom-build",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "MIT Open Learning custom build of CKEditor5",
   "main": "./build/ckeditor.js",
   "files": [
@@ -28,6 +28,7 @@
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-upload": "^10.0.3",
     "babel-eslint": "7.2.3",
+    "ckeditor5-emptyness": "https://github.com/alexeckermann/ckeditor5-emptyness",
     "eslint": "4.2.0",
     "eslint-config-google": "0.9.1",
     "eslint-config-mitodl": "^0.0.4",

--- a/sample/index.html
+++ b/sample/index.html
@@ -32,7 +32,7 @@ body {
 
         const editorContainer = document.querySelector("#editor")
 
-        ClassicEditor.create(JSON.parse(initialData))
+        CustomEditor.create(JSON.parse(initialData))
           .then(editor => {
 
             editorContainer.appendChild(
@@ -52,7 +52,7 @@ body {
 
         const readOnlyContainer = document.querySelector("#read-only-editor")
 
-        ClassicEditor.create(JSON.parse(initialData))
+        CustomEditor.create(JSON.parse(initialData))
           .then(editor => {
 
             readOnlyContainer.appendChild(editor.ui.view.editable.element);

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -15,7 +15,6 @@ import BlockQuote from "@ckeditor/ckeditor5-block-quote/src/blockquote"
 import EasyImage from "@ckeditor/ckeditor5-easy-image/src/easyimage"
 import Heading from "@ckeditor/ckeditor5-heading/src/heading"
 import Image from "@ckeditor/ckeditor5-image/src/image"
-import ImageCaption from "@ckeditor/ckeditor5-image/src/imagecaption"
 import ImageStyle from "@ckeditor/ckeditor5-image/src/imagestyle"
 import ImageToolbar from "@ckeditor/ckeditor5-image/src/imagetoolbar"
 import ImageUpload from "@ckeditor/ckeditor5-image/src/imageupload"
@@ -23,21 +22,20 @@ import Link from "@ckeditor/ckeditor5-link/src/link"
 import List from "@ckeditor/ckeditor5-list/src/list"
 import MediaEmbed from "@ckeditor/ckeditor5-media-embed/src/mediaembed"
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
-import Table from "@ckeditor/ckeditor5-table/src/table"
-import TableToolbar from "@ckeditor/ckeditor5-table/src/tabletoolbar"
+import Emptyness from "ckeditor5-emptyness/src/emptyness"
 
 // block toolbar setup
 import BlockToolbar from "@ckeditor/ckeditor5-ui/src/toolbar/block/blocktoolbar"
-import HeadingButtonsUI from "@ckeditor/ckeditor5-heading/src/headingbuttonsui"
 import ParagraphButtonUI from "@ckeditor/ckeditor5-paragraph/src/paragraphbuttonui"
 
 import JSONplugin from "./JSONDataProcessor"
 
-export default class ClassicEditor extends ClassicEditorBase {}
+export default class CustomEditor extends ClassicEditorBase {}
 
 // Plugins to include in the build.
-ClassicEditor.builtinPlugins = [
+CustomEditor.builtinPlugins = [
   Essentials,
+  Emptyness,
   UploadAdapter,
   Autoformat,
   Bold,
@@ -46,7 +44,6 @@ ClassicEditor.builtinPlugins = [
   EasyImage,
   Heading,
   Image,
-  ImageCaption,
   ImageStyle,
   ImageToolbar,
   ImageUpload,
@@ -54,48 +51,27 @@ ClassicEditor.builtinPlugins = [
   List,
   MediaEmbed,
   Paragraph,
-  Table,
-  TableToolbar,
   BlockToolbar,
   ParagraphButtonUI,
-  HeadingButtonsUI,
   JSONplugin
 ]
 
 // Editor configuration.
-ClassicEditor.defaultConfig = {
-  blockToolbar: [
-    "paragraph",
-    "heading1",
-    "heading2",
-    "heading3",
-    "|",
-    "bulletedList",
-    "numberedList",
-    "|",
-    "blockQuote",
-    "imageUpload"
-  ],
-  toolbar: {
+CustomEditor.defaultConfig = {
+  blockToolbar: ["paragraph", "mediaEmbed", "imageUpload"],
+  toolbar:      {
     items: [
+      "heading",
       "bold",
       "italic",
       "link",
       "bulletedList",
       "numberedList",
-      // "imageUpload",
-      "blockQuote",
-      "insertTable",
-      "mediaEmbed",
-      "undo",
-      "redo"
+      "blockQuote"
     ]
   },
   image: {
     toolbar: ["imageStyle:full", "imageStyle:side", "|", "imageTextAlternative"]
-  },
-  table: {
-    contentToolbar: ["tableColumn", "tableRow", "mergeTableCells"]
   },
   // This value must be kept in sync with the language defined in webpack.config.js.
   language: "en"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,14 @@ circular-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
+"ckeditor5-emptyness@https://github.com/alexeckermann/ckeditor5-emptyness":
+  version "0.2.1"
+  resolved "https://github.com/alexeckermann/ckeditor5-emptyness#693a5c77f659f1cb141591c9cd78427ebc72b550"
+  dependencies:
+    "@ckeditor/ckeditor5-core" "^11.0.1"
+    "@ckeditor/ckeditor5-engine" "^11.0.0"
+    "@ckeditor/ckeditor5-utils" "^11.0.0"
+
 ckeditor5@^11.1.0:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-11.1.1.tgz#f2da24b01a659e848ef6a4dd125ff5cc9e1cb06f"


### PR DESCRIPTION
this makes the changes that need to be made over here for https://github.com/mitodl/open-discussions/issues/1583

it also addresses https://github.com/mitodl/open-discussions/issues/1572 (removing the image caption plugin)

things that should be there:

- an empty editor now has a `.ck-editor__is-empty` class on it
- no more image captions
- no more table insertion options
- changes (specified in https://github.com/mitodl/open-discussions/issues/1583) to the toolbar and the block toolbar are made

I think that's about it. the other changes will be made over in the open repo.